### PR TITLE
removed cytoscape from anonymous function call

### DIFF
--- a/cytoscape-qtip.js
+++ b/cytoscape-qtip.js
@@ -1,7 +1,7 @@
-;(function( $, $$ ){ 'use strict';
+;(function( $ ){ 'use strict';
 
   function register( $$, $ ){
-
+    if( !cytoscape ){ return; } // can't register if cytoscape unspecified
     // use a single dummy dom ele as target for every qtip
     var $qtipContainer = $('<div></div>');
     var viewportDebounceRate = 250;
@@ -186,8 +186,8 @@
     });
   }
 
-  if( $ && $$ ){
-    register( $$, $ );
+  if( typeof cytoscape !== 'undefined' ){ // expose to global cytoscape (i.e. window.cytoscape)
+    register( cytoscape, $ );
   }
   
-})( jQuery, cytoscape );
+})( jQuery );


### PR DESCRIPTION
Hi, Max:
I noticed that if I use cytoscape via require('cytoscape'), the cytoscape-qtip doesn't work very well, because the anonymous call expects `cytoscape` to be defined as global variable, which, if you use requirejs, won't be defined globally. I had a look at cytoscape-context-menu you wrote and did some change as per that project to fix the issue. Please have a look.