### PR TITLE
NO-REF - Use DOM to position toolip to allow `flip` to work.

### DIFF
--- a/cytoscape-qtip.js
+++ b/cytoscape-qtip.js
@@ -253,7 +253,6 @@ SOFTWARE.
         var opts = generateOpts( ele, passedOpts );
         var adjNums = opts.position.adjust;
 
-
         qtip.$domEle.qtip( opts );
         var qtipApi = qtip.api = qtip.$domEle.qtip('api'); // save api ref
         qtip.$domEle.removeData('qtip'); // remove qtip dom/api ref to be safe
@@ -297,9 +296,27 @@ SOFTWARE.
         updatePosition();
 
         ele.on( opts.show.event, function(e){
-          updatePosition(e);
+          var targetDom = $('<div></div>'),
+            cOff = container.getBoundingClientRect(),
+            bb = ele.renderedBoundingBox();
+
+          targetDom.css({
+            width: bb.w,
+            height: bb.h,
+            top: bb.y1 + cOff.top,
+            left: bb.x1 + cOff.left,
+            position: 'absolute'
+          });
+          targetDom.appendTo(document.body);
+
+          qtipApi.set('position.target', targetDom);
+          qtipApi.set('position.adjust.x', 0);
+          qtipApi.set('position.adjust.y', 0);
 
           qtipApi.show();
+
+          // Remove our temporary target DOM.
+          targetDom.remove();
         } );
 
         ele.on( opts.hide.event, function(e){


### PR DESCRIPTION
qTip has great support for the viewport flip/shift adjustments that will switch the tooltip positions when approaching viewport boundaries. However, it requires DOM elements to do computation, and the manual adjustments that we currently apply do not play nicely with that tooling. To address this I took the approach of adding a temporary DOM element to provide to qTip (and then immediately remove it). We could do this, or simply add a PR to qTip to allow passing an object to `position.target` with `{x: ele.x, y: ele.y, width: ele.width, height: ele.height}` (which they do not support, they support `[x, y]` but it needs width to allow things like flip to work.

How do you feel about fixing this here vs upstream? I think there might be more advantages to using a proper DOM el for qtip like I do, but wanted to lay out my thinking.

Cheers,
Nowell
