### PR TITLE
Support for jQuery 3.x

### DIFF
--- a/cytoscape-qtip.js
+++ b/cytoscape-qtip.js
@@ -52,6 +52,10 @@ SOFTWARE.
     }
   };
 
+  var fixDomContainer = function(ele) {
+    return ele[0] === window ? undefined : ele;
+  };
+
   var throttle = function(func, wait, options) {
     var leading = true,
         trailing = true;
@@ -196,8 +200,8 @@ SOFTWARE.
 
       // qtip should be positioned relative to cy dom container
       opts.position = opts.position || {};
-      opts.position.container = opts.position.container || $( document.body );
-      opts.position.viewport = opts.position.viewport || $( document.body );
+      opts.position.container = fixDomContainer(opts.position.container) || $( document.body );
+      opts.position.viewport = fixDomContainer(opts.position.viewport) || $( document.body );
       opts.position.target = [0, 0];
       opts.position.my = opts.position.my || 'top center';
       opts.position.at = opts.position.at || 'bottom center';

--- a/cytoscape-qtip.js
+++ b/cytoscape-qtip.js
@@ -53,7 +53,7 @@ SOFTWARE.
   };
 
   var fixDomContainer = function(ele) {
-    return ele[0] === window ? undefined : ele;
+    return ele && ( ele[0] === window ) ? undefined : ele;
   };
 
   var throttle = function(func, wait, options) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "run-sequence": "^1.0.0"
   },
   "dependencies": {
-    "jquery": "^2.0 || ^1.10.0",
+    "jquery": "^3.0.0 || ^2.0 || ^1.10.0",
     "qtip2": "^3.0 || ^2.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Added jQuery 3.x in package.json + the same compatibility fix as in qTip2/qTip2#818

See https://github.com/cytoscape/cytoscape.js-qtip/issues/33 for details.