### PR TITLE
fix: TypeError on getting API of non-initialized qTip

### DIFF
--- a/cytoscape-qtip.js
+++ b/cytoscape-qtip.js
@@ -289,7 +289,7 @@ SOFTWARE.
       var container = cy.container();
 
       if( passedOpts === 'api' ){
-		var qtip = this.scratch().qtip;
+        var qtip = this.scratch().qtip;
         return qtip ? qtip.api : null;
       }
 

--- a/cytoscape-qtip.js
+++ b/cytoscape-qtip.js
@@ -289,7 +289,8 @@ SOFTWARE.
       var container = cy.container();
 
       if( passedOpts === 'api' ){
-        return this.scratch().qtip.api;
+		var qtip = this.scratch().qtip;
+        return qtip ? qtip.api : null;
       }
 
       eles.each(function(ele, i){
@@ -342,7 +343,8 @@ SOFTWARE.
       var container = cy.container();
 
       if( passedOpts === 'api' ){
-        return this.scratch().qtip.api;
+        var qtip = this.scratch().qtip;
+        return qtip ? qtip.api : null;
       }
 
       var scratch = cy.scratch();


### PR DESCRIPTION
If qTip is not initialized on eles yet, calling eles.qtip('api') leads to TypeError "Cannot read property 'api' of undefined".
This pull request fixes the issue.